### PR TITLE
Remove Redundant Project

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt
@@ -46,15 +46,15 @@ class Kapt3GradleSubplugin @Inject internal constructor(private val registry: To
 
         @JvmStatic
         fun getKaptGeneratedClassesDir(project: Project, sourceSetName: String) =
-            File(project.project.buildDir, "tmp/kapt3/classes/$sourceSetName")
+            File(project.buildDir, "tmp/kapt3/classes/$sourceSetName")
 
         @JvmStatic
         fun getKaptGeneratedSourcesDir(project: Project, sourceSetName: String) =
-            File(project.project.buildDir, "generated/source/kapt/$sourceSetName")
+            File(project.buildDir, "generated/source/kapt/$sourceSetName")
 
         @JvmStatic
         fun getKaptGeneratedKotlinSourcesDir(project: Project, sourceSetName: String) =
-            File(project.project.buildDir, "generated/source/kaptKotlin/$sourceSetName")
+            File(project.buildDir, "generated/source/kaptKotlin/$sourceSetName")
     }
 
     override fun apply(project: Project) {


### PR DESCRIPTION
Just some syntax cleanup when visting the file.
Note: I was trying to understand why the output folders of kapt are creating so eagerly in a build, during configuration time indeed...(they should be created later, during execution).